### PR TITLE
chore: Rename project to github-stats-analyser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "repository-analysis"
+name = "github-stats-analyser"
 version = "0.1.0"
 description = ""
 authors = ["Jack Plowman <62281988+JackPlowman@users.noreply.github.com>"]


### PR DESCRIPTION
# Pull Request

## Description

This change updates the project name in the `pyproject.toml` file from "repository-analysis" to "github-stats-analyser". This modification aligns the project name with its intended purpose and improves clarity for users and contributors.

fixes #60