### PR TITLE
chore: Add Dockerfile and Docker build command

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,6 +25,10 @@ github_actions:
       - changed-files:
           - any-glob-to-any-file:
               [".github/workflows/*", ".github/workflows/**/*"]
+docker:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Dockerfile"]
 analyser:
   - any:
       - changed-files:

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -58,6 +58,9 @@
 - color: 00ff44
   name: shell
   description: Pull requests that update Shell code
+- color: 0373fc
+  name: docker
+  description: Pull requests that update Docker code
 # Components
 - color: f200f2
   name: analyser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+#checkov:skip=CKV_DOCKER_2
+#checkov:skip=CKV_DOCKER_3
+FROM python:3.12-alpine
+
+WORKDIR /analyser
+
+COPY pyproject.toml poetry.lock ./
+RUN pip install --no-cache-dir poetry==1.8.3 \
+  && poetry install --no-dev
+
+COPY analyser ./analyser
+
+CMD [ "python", "-m", "analyser" ]

--- a/Justfile
+++ b/Justfile
@@ -42,6 +42,10 @@ unit-test-debug:
 validate-schema:
     poetry run check-jsonschema --schemafile test/schema_validation/repository_statistics_schema.json test/schema_validation/repository_statistics.json
 
+# Build the Docker image
+docker-build:
+    docker build -t jackplowman/github-stats-analyser:latest .
+
 # ------------------------------------------------------------------------------
 # Ruff - Set up red-knot when it's ready
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a Dockerfile for containerizing the application and adds Docker-related configurations to the project.

The Dockerfile:
- Uses Python 3.12 Alpine as the base image
- Sets up the working directory
- Copies and installs dependencies using Poetry
- Copies the application code
- Specifies the command to run the application

The Justfile update:
- Adds a new `docker-build` task to build the Docker image with the tag `jackplowman/github-stats-analyser:latest`

Updates to GitHub configurations:
- Adds a new 'docker' label in `labels.yml`
- Configures the labeller in `labeller.yml` to automatically apply the 'docker' label to PRs that modify the Dockerfile

These changes enable easier deployment and distribution of the application in containerised environments.

fixes #59