### PR TITLE
ci: Add Docker build and test job to code-test workflow

### DIFF
--- a/.github/workflows/code-build.yml
+++ b/.github/workflows/code-build.yml
@@ -1,0 +1,32 @@
+name: Code Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build-and-run:
+    name: Build Docker Image and Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        run: just docker-build
+
+      - name: Run Docker Image
+        run: just docker-run

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@
 #checkov:skip=CKV_DOCKER_3
 FROM python:3.12-alpine
 
-WORKDIR /analyser
+WORKDIR /
+
+RUN mkdir -p /statistics && \
+  apk add git=2.45.2-r0
 
 COPY pyproject.toml poetry.lock ./
+
 RUN pip install --no-cache-dir poetry==1.8.3 \
   && poetry install --no-dev
 
 COPY analyser ./analyser
 
-CMD [ "python", "-m", "analyser" ]
+CMD [ "poetry", "run", "python", "-m", "analyser" ]

--- a/Justfile
+++ b/Justfile
@@ -42,9 +42,19 @@ unit-test-debug:
 validate-schema:
     poetry run check-jsonschema --schemafile test/schema_validation/repository_statistics_schema.json test/schema_validation/repository_statistics.json
 
+# ------------------------------------------------------------------------------
+# Docker
+# ------------------------------------------------------------------------------
+
 # Build the Docker image
 docker-build:
     docker build -t jackplowman/github-stats-analyser:latest .
+
+docker-run:
+    docker run \
+      --env REPOSITORY_OWNER=JackPlowman \
+      --volume "$(pwd)/statistics:/statistics" \
+      --rm jackplowman/github-stats-analyser:latest
 
 # ------------------------------------------------------------------------------
 # Ruff - Set up red-knot when it's ready


### PR DESCRIPTION
# Pull Request

## Description

This change adds a new job called `docker-test` to the GitHub Actions workflow. The job builds and runs a Docker image to test the GitHub Stats Analyser.

The new job includes the following steps:
1. Checkout the repository
2. Set up Docker Buildx
3. Build the Docker image using the `just docker-build` command
4. Run the Docker image with a sample repository owner

This addition ensures that the Docker image can be successfully built and executed as part of the continuous integration process, providing an additional layer of testing for the project.

fixes #64