### PR TITLE
ci: Fix SonarCloud coverage path and update test commands

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run Unit Tests
         run: just unit-test
 
+      - name: Override Coverage Source Path for SonarCloud
+        run: sed -i "s/<source>\/home\/runner\/work\/github-stats-analyser\/github-stats-analyser<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/github-stats-analyser/github-stats-analyser/coverage.xml
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3.0.0
         env:

--- a/Justfile
+++ b/Justfile
@@ -34,10 +34,10 @@ run-with-defaults:
     DEBUG=true REPOSITORY_OWNER=JackPlowman poetry run python -m analyser
 
 unit-test:
-    poetry run pytest analyser --cov=analyser --cov-report=xml
+    poetry run pytest analyser --cov=. --cov-report=xml
 
 unit-test-debug:
-    poetry run pytest analyser --cov=analyser --cov-report=xml -vvvv
+    poetry run pytest analyser --cov=. --cov-report=xml -vvvv
 
 validate-schema:
     poetry run check-jsonschema --schemafile test/schema_validation/repository_statistics_schema.json test/schema_validation/repository_statistics.json


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the code coverage reporting and SonarCloud integration in the project:

1. Updated the `unit-test` and `unit-test-debug` commands in the Justfile to use `--cov=.` instead of `--cov=analyser`. This modification ensures that code coverage is calculated for the entire project rather than just the `analyser` directory.

2. Added a new step in the GitHub Actions workflow (`code-test.yml`) to override the coverage source path for SonarCloud. This step uses `sed` to replace the source path in the `coverage.xml` file, ensuring that SonarCloud can correctly map the coverage data to the source code.

These changes aim to improve the accuracy and completeness of code coverage reporting, particularly when integrating with SonarCloud for code quality analysis.

fixes #69