### PR TITLE
chore: Remove version from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.poetry]
 name = "github-stats-analyser"
-version = "0.1.0"
 description = ""
 authors = ["Jack Plowman <62281988+JackPlowman@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
# Pull Request

## Description

This change removes the version specification from the `pyproject.toml` file. The `version = "0.1.0"` line has been deleted, which allows for more flexible version management of the project. This modification can be beneficial when using automated versioning tools or when the version is managed through other means, such as git tags or CI/CD pipelines.

fixes #78