### PR TITLE
fix: Fix GitHub Action Run Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.12-alpine
 WORKDIR /
 
 RUN mkdir -p /statistics && \
-  apk add git=2.45.2-r0 --no-cache
+  apk add --no-cache git=2.45.2-r0
 
 COPY pyproject.toml poetry.lock ./
 
@@ -14,4 +14,4 @@ RUN pip install --no-cache-dir poetry==1.8.3 \
 
 COPY analyser ./analyser
 
-CMD [ "poetry", "run", "python", "-m", "analyser" ]
+ENTRYPOINT [ "poetry", "run", "python", "-m", "analyser" ]


### PR DESCRIPTION
# Pull Request

## Description

This change optimises the Dockerfile for the analyser project:

1. Improved the `apk add` command by moving the `--no-cache` flag to the beginning, following best practices for Alpine Linux package management.

2. Replaced the `CMD` instruction with `ENTRYPOINT`, ensuring that the analyser module is always executed when the container starts, regardless of any additional command-line arguments passed to `docker run`.

fixes #82

<img width="1522" alt="image" src="https://github.com/user-attachments/assets/766eda0b-a90d-4ca6-ad64-e0147a0cc230">
