### PR TITLE
chore: Fix script not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ WORKDIR /
 RUN mkdir -p /statistics && \
   apk add --no-cache git=2.45.2-r0
 
-COPY run.sh /
-RUN chmod +x /run.sh
+COPY --chmod=755 run.sh run.sh
 
 COPY pyproject.toml poetry.lock /
 
@@ -17,4 +16,4 @@ RUN pip install --no-cache-dir poetry==1.8.3 \
 
 ENV PYTHONPATH=/
 
-ENTRYPOINT [ "sh", "run.sh" ]
+ENTRYPOINT [ "/run.sh" ]

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Show files
 ls -la


### PR DESCRIPTION
# Pull Request

## Description

This change optimises the Dockerfile and run script:

- Simplifies the `COPY` command for `run.sh` by using the `--chmod` flag to set permissions in a single step.
- Updates the `ENTRYPOINT` to directly execute `run.sh` without invoking `sh`.
- Changes the shebang in `run.sh` from `#!/bin/bash` to `#!/bin/sh` for better compatibility with Alpine Linux.

These modifications streamline the Docker image build process and improve the execution of the entry point script.

fixes #92