### PR TITLE
chore: Fix analyser directory copy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /statistics && \
 
 COPY --chmod=755 run.sh run.sh
 
-COPY pyproject.toml poetry.lock analyser/ ./
+COPY pyproject.toml poetry.lock analyser ./
 
 RUN pip install --no-cache-dir poetry==1.8.3 \
   && poetry install --no-dev


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the `COPY` command in the Dockerfile to correctly copy the `analyser` directory. The previous command was attempting to copy `analyser/` as a file, which could lead to issues during the Docker build process. The updated command removes the trailing slash, ensuring that the entire `analyser` directory and its contents are properly copied into the Docker image.

This modification ensures that all necessary files from the `analyser` directory are included in the Docker image, which is crucial for the proper functioning of the application within the container.

fixes #95