### PR TITLE
chore: Update Dockerfile and enhance run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN mkdir -p /statistics && \
 
 COPY --chmod=755 run.sh run.sh
 
-COPY pyproject.toml poetry.lock analyser ./
+COPY analyser analyser
+COPY pyproject.toml poetry.lock ./
 
 RUN pip install --no-cache-dir poetry==1.8.3 \
   && poetry install --no-dev

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e +x
 
 # Echo cwd
 echo "Current working directory: $(pwd)"


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the Dockerfile and run.sh script to improve the container setup and execution process.

In the Dockerfile:
- The `analyser` directory is now copied separately from the `pyproject.toml` and `poetry.lock` files.

In the run.sh script:
- Added `set -e +x` at the beginning to exit on errors and disable command echoing.

These changes aim to enhance the reliability and transparency of the container's execution environment.

fixes #98