### PR TITLE
build: Copy output file to GitHub runner

### DIFF
--- a/.github/workflows/action-preview.yml
+++ b/.github/workflows/action-preview.yml
@@ -16,10 +16,3 @@ jobs:
         uses: JackPlowman/github-stats-analyser@main
         with:
           repository_owner: ${{ github.repository_owner }}
-
-      - name: Check Files
-        run: |
-          ls -la
-          ls -la statistics
-          ls -la cloned_repositories
-          ls -la analyser

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ author: "Jack Plowman"
 runs:
   using: "docker"
   image: "Dockerfile"
+  env:
+    GITHUB_ACTION: "true"
 inputs:
   github_token:
     description: "The GitHub token"

--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 set -e +x
 
-cd ..
-cd ..
-# Echo cwd
-echo "Current working directory: $(pwd)"
-# Show files
-ls -la
-
-printenv
+if [ "$GITHUB_ACTION" = "true" ]; then
+  # if running in GitHub Actions, change to the root of the repository
+  cd ..
+  cd ..
+fi
 
 # Run the analyser
 python -m analyser
+
+# Check the output
+ls -a
+
+if [ "$GITHUB_ACTION" = "true" ]; then
+  # if running in GitHub Actions, copy the output to the output directory
+  cp statistics/repository_statistics.json github/workspace/repository_statistics.json
+fi


### PR DESCRIPTION
# Pull Request

## Description

This change streamlines the GitHub Actions workflow and enhances the output handling of the analyser:

1. Removed unnecessary file checking steps from the `action-preview.yml` workflow file.
2. Simplified the `run.sh` script by:
   - Removing debug echo statements and environment variable printing
   - Adding a step to check the output using `ls -a`
   - Implementing a step to copy the `repository_statistics.json` file to the GitHub workspace

These modifications improve the efficiency of the workflow and ensure that the analysis results are properly stored in the expected location.

fixes #104