### PR TITLE
chore: Remove debug commands from run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e +x
 
-printenv
-
 if [ "$CI" = "true" ]; then
   # if running in GitHub Actions, change to the root of the repository
   cd ..
@@ -11,9 +9,6 @@ fi
 
 # Run the analyser
 python -m analyser
-
-# Check the output
-ls -a
 
 if [ "$CI" = "true" ]; then
   # if running in GitHub Actions, copy the output to the output directory


### PR DESCRIPTION
# Pull Request

## Description

This change streamlines the `run.sh` script by removing unnecessary debug commands. Specifically:

1. Removed the `printenv` command at the beginning of the script.
2. Eliminated the `ls -a` command that was used to check the output.

These modifications help to reduce noise in the script's output and focus on the essential operations. The core functionality of running the analyser and handling CI-specific tasks remains unchanged.

fixes #105