### PR TITLE
chore: Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github
+.vscode
+docs
+githooks
+statistics
+test


### PR DESCRIPTION
# Pull Request

## Description

This change adds a new `.dockerignore` file to the project. The file specifies directories and folders that should be excluded from the Docker build context. The ignored paths include:

- `.github`
- `.vscode`
- `docs`
- `githooks`
- `statistics`
- `test`

By excluding these directories, we can reduce the size of the Docker build context and potentially speed up the build process. This change also helps prevent unnecessary files from being included in the Docker image, improving its overall efficiency and reducing potential security risks.

fixes #114