### PR TITLE
chore: Group GitHub Actions dependencies in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
# Pull Request

## Description

This change updates the Dependabot configuration for GitHub Actions. It introduces a new grouping strategy for GitHub Actions dependencies. All GitHub Actions dependencies will now be grouped together under the "github-actions" group. This modification aims to streamline the dependency update process by consolidating related updates into a single pull request, potentially reducing the number of individual PRs created by Dependabot.

fixes #117