### PR TITLE
chore: Standardise environment variable names

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Check Markdown links
         uses: UmbrellaDocs/action-linkspector@v1.2.2
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
           reporter: github-pr-review
           fail_on_error: true

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run GitHub Stats Analyser
         uses: ./
         with:
-          repository_owner: ${{ github.repository_owner }}
+          REPOSITORY_OWNER: ${{ github.REPOSITORY_OWNER }}
 
       - name: Copy generated files to github pages folder
         run: cp repository_statistics.json test/schema_validation

--- a/Justfile
+++ b/Justfile
@@ -66,7 +66,7 @@ docker-build:
 # Run the analyser in a Docker container, used for testing the github action docker image
 docker-run:
     docker run \
-      --env github_token=${GITHUB_TOKEN} \
+      --env GITHUB_TOKEN=${GITHUB_TOKEN} \
       --env INPUT_REPOSITORY_OWNER=JackPlowman \
       --volume "$(pwd)/statistics:/statistics" \
       --volume "$(pwd)/cloned_repositories:/cloned_repositories" \

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The GitHub Action is designed to be used in a workflow.
 - name: Analyse GitHub repositories
   uses: jackplowman/github-stats-analyser@latest
   with:
-    repository_owner: jackplowman # Put your GitHub username here or use ${{ github.repository_owner }}
+    REPOSITORY_OWNER: jackplowman # Put your GitHub username here or use ${{ github.REPOSITORY_OWNER }}
 ```
 
 ### GitHub Action Inputs
 
 | Name               | Required | Description                                         | Type   | Default               |
 | ------------------ | -------- | --------------------------------------------------- | ------ | --------------------- |
-| `repository_owner` | yes      | The GitHub username of the repositories to analyse. | string | N/A                   |
+| `REPOSITORY_OWNER` | yes      | The GitHub username of the repositories to analyse. | string | N/A                   |
 | `github-token`     | no       | A GitHub token to authenticate API requests.        | string | `${{ github.token }}` |

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ runs:
   env:
     GITHUB_ACTION: "true"
 inputs:
-  github_token:
+  GITHUB_TOKEN:
     description: "The GitHub token"
     required: false
     default: ${{ github.token }}
-  repository_owner:
+  REPOSITORY_OWNER:
     description: "The GitHub repository owner"
     required: true
 branding:

--- a/analyser/utils/github_interactions.py
+++ b/analyser/utils/github_interactions.py
@@ -36,11 +36,8 @@ def retrieve_repositories() -> PaginatedList[Repository]:
     Returns:
         PaginatedList[Repository]: The list of repositories.
     """
-    repository_owner = getenv("INPUT_REPOSITORY_OWNER")
-    token = getenv("INPUT_GITHUB_TOKEN")
-    github = Github(token)
-    logger.debug("Using authenticated GitHub API")
-    repositories = github.search_repositories(query=f"user:{repository_owner} archived:false")
+    github = Github(getenv("INPUT_GITHUB_TOKEN"))
+    repositories = github.search_repositories(query=f'user:{getenv("INPUT_REPOSITORY_OWNER")} archived:false')
     logger.info(
         "Found repositories",
         repositories_count=repositories.totalCount,

--- a/analyser/utils/tests/test_github_interactions.py
+++ b/analyser/utils/tests/test_github_interactions.py
@@ -35,7 +35,7 @@ def test_clone_repo_exists(mock_repo: MagicMock, mock_path: MagicMock) -> None:
 def test_retrieve_repositories(mock_getenv: MagicMock, mock_github: MagicMock) -> None:
     # Arrange
     token = "TestToken"  # noqa: S105
-    mock_getenv.side_effect = ["Test", token]
+    mock_getenv.side_effect = [token, "Test"]
     full_name = "Test3/Test4"
     mock_github.return_value.search_repositories.return_value = search_return = MagicMock(
         totalCount=1, list=[MagicMock(full_name=full_name)]
@@ -44,5 +44,5 @@ def test_retrieve_repositories(mock_getenv: MagicMock, mock_github: MagicMock) -
     repositories = retrieve_repositories()
     # Assert
     mock_github.assert_called_once_with(token)
-    mock_getenv.assert_has_calls([call("INPUT_REPOSITORY_OWNER"), call("INPUT_GITHUB_TOKEN")])
+    mock_getenv.assert_has_calls([call("INPUT_GITHUB_TOKEN"), call("INPUT_REPOSITORY_OWNER")])
     assert repositories == search_return


### PR DESCRIPTION
# Pull Request

## Description

This change updates the naming convention for environment variables and input parameters across the project. Specifically:

- In GitHub workflows, `github_token` is renamed to `GITHUB_TOKEN`.
- In the Docker run command, `github_token` is updated to `GITHUB_TOKEN`.
- The `repository_owner` input parameter is renamed to `REPOSITORY_OWNER` in various files including README.md, action.yml, and GitHub workflows.
- The corresponding environment variable `INPUT_REPOSITORY_OWNER` remains unchanged in the Python code.

These changes aim to improve consistency in naming conventions throughout the project, particularly for GitHub-related variables and inputs.

fixes #130