### PR TITLE
chore: Add setup-dependencies directory to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - ".github/actions/setup-dependencies"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:


### PR DESCRIPTION
# Pull Request

## Description

This change updates the Dependabot configuration to monitor GitHub Actions dependencies in an additional directory. Specifically, it adds the ".github/actions/setup-dependencies" directory to the list of monitored paths. This ensures that Dependabot will check for updates in both the root directory and the setup-dependencies action directory, potentially improving the maintenance and security of the project's GitHub Actions.

fixes #134