### PR TITLE
chore: Optimize pre-commit hook for Python files

### DIFF
--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e +x
 
-just install
-just ruff-fix
+# Check if there are any changes in the watched folder
+if git diff --cached --name-only | grep -q "^analyser/"; then
+  just install
+  just ruff-fix
+fi


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the `python.sh` script in the `githooks/pre-commit-scripts` directory to conditionally run the `just install` and `just ruff-fix` commands. The script now checks if there are any changes in the `analyser/` folder before executing these commands. This optimization ensures that the pre-commit hooks only run when necessary, potentially improving the commit process efficiency.

fixes #141