### PR TITLE
chore: Fix Docker image reference in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 runs:
   using: "docker"
-  uses: docker://ghcr.io/jackplowman/github-stats-analyser:v1.1.0
+  image: docker://ghcr.io/jackplowman/github-stats-analyser:v1.1.0
   env:
     GITHUB_ACTION: "true"
 


### PR DESCRIPTION
# Pull Request

## Description

This change updates the `action.yml` file to use the correct syntax for specifying a Docker image in GitHub Actions. The `uses` key has been replaced with `image` to properly reference the Docker image for the GitHub Stats Analyser action. This modification ensures that the action will correctly utilise the specified Docker image when running.

fixes #150