### PR TITLE
chore: Force color output in logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ runs:
   image: docker://ghcr.io/jackplowman/github-stats-analyser:v1.1.0
   env:
     GITHUB_ACTION: "true"
+    FORCE_COLOR: "true" # Force log colour output
 
 inputs:
   GITHUB_TOKEN:


### PR DESCRIPTION
# Pull Request

## Description

This change adds a new environment variable `FORCE_COLOR` set to "true" in the action configuration. This modification ensures that the log output will be displayed in coloir, enhancing readability and visual distinction of different log levels or message types when the action is executed.

fixes #163