### PR TITLE
ci: Simplify Docker build job name and description

### DIFF
--- a/.github/workflows/code-build.yml
+++ b/.github/workflows/code-build.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  docker-build-and-run:
-    name: Build Docker Image and Run
+  docker-build:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the `.github/workflows/code-build.yml` file, focusing on the job definition. The job name has been updated from `docker-build-and-run` to `docker-build`, and its display name has been changed from "Build Docker Image and Run" to "Build Docker Image". This adjustment suggests that the job's scope has been narrowed to only building the Docker image, removing the "run" aspect from its responsibilities.

fixes #167