### PR TITLE
ci: Update workflow trigger conditions

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -2,9 +2,10 @@ name: Code Test
 
 on:
   push:
-    branches: [main, "!release-please-*"]
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore: [release-please-*]
 
 permissions:
   contents: read


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the GitHub Actions workflow for code testing. It adjusts the trigger conditions for the workflow:

1. For push events, the workflow now only runs on the `main` branch, removing the exclusion for `release-please-*` branches.

2. For pull request events, a new `branches-ignore` condition is added to exclude `release-please-*` branches.

These adjustments help streamline the workflow execution by focusing on relevant branches and avoiding unnecessary runs on release-related branches.

fixes #169