### PR TITLE
chore: Add size labels to GitHub configuration

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -68,3 +68,22 @@
 - color: ff0073
   name: git_hooks
   description: Pull requests that update git hooks
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request


### PR DESCRIPTION
# Pull Request

## Description

This change adds new labels to categorise pull requests based on their size. The following size labels have been introduced:

- XS (Extra Small)
- S (Small)
- M (Medium)
- L (Large)
- XL (Extra Large)
- XXL (Extra Extra Large)

Each size label is assigned a unique colour for easy visual identification. These labels will help streamline the review process by providing a quick indication of the scope and complexity of each pull request.

fixes #180