### PR TITLE
ci: Add size labels to pull requests

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -25,12 +25,29 @@ jobs:
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
+
   labeller:
-    name: Labeller
+    name: Label Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5.0.0
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
+
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          with:
+          sizes: >
+            {
+              "0": "XS",
+              "20": "S",
+              "50": "M",
+              "200": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the pull request labelling process in the GitHub Actions workflow. The existing labeller action is now more explicitly named, and a new size labelling action has been added. 

The size labelling action automatically categorises pull requests based on the number of lines changed, using the following scale:
- XS: 0-19 lines
- S: 20-49 lines
- M: 50-199 lines
- L: 200-499 lines
- XL: 500-999 lines
- XXL: 1000+ lines

This addition will help quickly identify the scope of changes in pull requests, improving the review process and overall project management.

fixes #181