### PR TITLE
ci: Adjust PR size label thresholds

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -41,13 +41,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          with:
+        with:
           sizes: >
             {
               "0": "XS",
-              "20": "S",
-              "50": "M",
+              "40": "S",
+              "100": "M",
               "200": "L",
-              "500": "XL",
-              "1000": "XXL"
+              "800": "XL",
+              "2000": "XXL"
             }


### PR DESCRIPTION
# Pull Request

## Description

This change updates the size thresholds for pull request labelling in the GitHub Actions workflow. The modifications adjust the number of lines that correspond to each size category:

- Small (S) now applies to changes between 40 and 99 lines (previously 20-49)
- Medium (M) now applies to changes between 100 and 199 lines (previously 50-199)
- Extra Large (XL) now applies to changes between 800 and 1999 lines (previously 500-999)
- Extra Extra Large (XXL) now applies to changes of 2000 lines or more (previously 1000+)

These adjustments aim to provide a more accurate representation of pull request sizes, potentially improving the assessment of code changes and their complexity.

fixes #186