### PR TITLE
ci: Refactor Workflow Triggers

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize]
   schedule:
     - cron: 30 1 * * 0
 

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -2,14 +2,7 @@ name: "Pull Request Tasks"
 
 on:
   pull_request:
-    types:
-      [
-        opened,
-        edited,
- 
-        synchronize,
-
-      ]
+    types: [opened, edited, synchronize]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -6,11 +6,9 @@ on:
       [
         opened,
         edited,
-        unlocked,
-        labeled,
+ 
         synchronize,
-        reopened,
-        ready_for_review,
+
       ]
 
 permissions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes changes to the GitHub Actions workflow configuration files to streamline the types of pull request events that trigger workflows.

Workflow configuration updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L7-R7): Removed `reopened` and `ready_for_review` from the list of pull request event types that trigger the workflow.
* [`.github/workflows/code-test.yml`](diffhunk://#diff-314826f729648f76fab59d2066fee8574a22e74248fdf3080cada0d804b8bc56L7-R7): Removed `reopened` and `ready_for_review` from the list of pull request event types that trigger the workflow.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL9-R11): Removed `unlocked`, `labeled`, `reopened`, and `ready_for_review` from the list of pull request event types that trigger the workflow.

Fixes #202 
