### PR TITLE
ci: Add OpenSSF Scorecard Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,13 +11,13 @@ on:
 permissions:
   contents: read
   packages: read
-  statuses: write
-  security-events: write
 
 jobs:
   check-code-quality:
     name: Check Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -46,6 +46,8 @@ jobs:
   check-python-code-format-and-quality:
     name: Check Python Code Format and Quality
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -71,6 +73,9 @@ jobs:
   upload-ruff-analysis-results:
     name: Upload Ruff Analysis Results
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -96,6 +101,8 @@ jobs:
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
@@ -110,6 +117,8 @@ jobs:
   check-markdown-links:
     name: Check Markdown links
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -128,6 +137,8 @@ jobs:
   check-justfile-format:
     name: Check Justfile Format
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -143,6 +154,8 @@ jobs:
   docker-build:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -157,6 +170,31 @@ jobs:
 
       - name: Build Docker Image
         run: just docker-build
+
+  run-scorecard-analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+      id-token: write
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v3.27.4
+        with:
+          sarif_file: results.sarif
 
   run-code-limit:
     name: Code Limit Analysis

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -175,9 +175,13 @@ jobs:
     name: Scorecard Analysis
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
       security-events: write
       id-token: write
+      contents: read
+      actions: read
+      issues: read
+      pull-requests: read
+      checks: read
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/workflows/code-checks.yml` file to adjust permissions and add a new job for Scorecard Analysis. The most important changes include adding permissions to various jobs and introducing the Scorecard Analysis job.

Changes to permissions:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L14-R20): Added `statuses: write` permission to the `check-code-quality`, `check-python-code-format-and-quality`, `upload-ruff-analysis-results`, `run-codeql-analysis`, `check-markdown-links`, `check-justfile-format`, and `docker-build` jobs. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L14-R20) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R49-R50) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R76-R78) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R104-R105) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R120-R121) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R140-R141) [[7]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R157-R158)
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R76-R78): Added `security-events: write` permission to the `upload-ruff-analysis-results` job.

New job addition:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R174-R198): Added a new job `run-scorecard-analysis` with `statuses: write`, `security-events: write`, and `id-token: write` permissions, and steps to checkout code, run analysis using `ossf/scorecard-action`, and upload results to code scanning.

Fixes #207 
