### PR TITLE
refactor: Fix Workflow Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -103,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/code-checks.yml` file. The change grants write permissions to `security-events` in the `jobs` section.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R106): Added `security-events: write` permission to the `jobs` section.

Fixes #214
