### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
@@ -21,7 +24,10 @@ updates:
     commit-message:
       prefix: "deps(python)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
@@ -33,5 +39,8 @@ updates:
     commit-message:
       prefix: "deps(docker)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/dependabot.yml` file to modify the update schedules for different dependency groups. The most important changes are:

Update schedule changes:

* Changed the update schedule for `github-actions` dependencies from daily to weekly, specifying updates on Saturdays at 01:00 in the Europe/London timezone.
* Changed the update schedule for `python` dependencies from monthly to weekly, specifying updates on Saturdays at 01:00 in the Europe/London timezone.
* Changed the update schedule for `docker` dependencies from monthly to weekly, specifying updates on Saturdays at 01:00 in the Europe/London timezone.

Fixes #230 