### PR TITLE
chore: Update GitHub Actions Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small but important change to the `.github/dependabot.yml` file. The change specifies the types of updates for `github-actions`, which now include both "patch" and "minor" updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R21-R23): Added `update-types` for `github-actions` to include "patch" and "minor" updates.

Fixes #232 