### PR TITLE
build: Run Ruff on All Python Code

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -81,7 +81,7 @@ docker-run:
       --rm jackplowman/github-stats-analyser:latest
 
 # ------------------------------------------------------------------------------
-# Ruff - Python Linting and Formating
+# Ruff - Python Linting and Formatting
 # Set up ruff red-knot when it's ready
 # ------------------------------------------------------------------------------
 
@@ -92,19 +92,19 @@ ruff-fix:
 
 # Check for Ruff issues
 ruff-lint:
-    poetry run ruff check analyser
+    poetry run ruff check .
 
 # Fix Ruff lint issues
 ruff-lint-fix:
-    poetry run ruff check analyser --fix
+    poetry run ruff check . --fix
 
 # Check for Ruff format issues
 ruff-format:
-    poetry run ruff format --check analyser
+    poetry run ruff format --check .
 
 # Fix Ruff format issues
 ruff-format-fix:
-    poetry run ruff format analyser
+    poetry run ruff format .
 
 # ------------------------------------------------------------------------------
 # Other Python Tools


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `Justfile` to correct a typographical error and modify the `ruff` commands to apply to the entire project directory.

Typographical correction:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL84-R84): Corrected the spelling of "Formatting" in the comment for Ruff.

Modification of `ruff` commands:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL95-R107): Updated the `ruff-lint`, `ruff-lint-fix`, `ruff-format`, and `ruff-format-fix` commands to check and fix issues for the entire project directory instead of just the `analyser` directory.
