### PR TITLE
feat!: Reformat JSON Output and Add Repository Owner

### DIFF
--- a/analyser/statistics.py
+++ b/analyser/statistics.py
@@ -1,3 +1,6 @@
+from json import dump
+from pathlib import Path
+
 import git
 from pandas import DataFrame
 from structlog import get_logger, stdlib
@@ -42,7 +45,7 @@ def create_statistics(configuration: Configuration) -> DataFrame:
             for repository in list_of_repositories
         ]
     )
-    dataframe.to_json(DEFAULT_FILE_LOCATION, orient="records")
+    generate_output_file(configuration, dataframe)
     logger.debug("Saved statistics to file", file_location=DEFAULT_FILE_LOCATION)
     return dataframe
 
@@ -75,3 +78,20 @@ def create_repository_statistics(repository_name: str, path_to_repo: str) -> Cat
         commits=commits,
         languages=analysed_repository.languages.get_data(),
     )
+
+
+def generate_output_file(configuration: Configuration, dataframe: DataFrame) -> None:
+    """Generate an output file.
+
+    Args:
+        configuration (Configuration): The configuration.
+        dataframe (DataFrame): The data frame.
+    """
+    with Path(DEFAULT_FILE_LOCATION).open("w") as file:
+        dump(
+            {
+                "repository_owner": configuration.repository_owner,
+                "repositories": dataframe.to_dict(orient="records"),
+            },
+            file,
+        )

--- a/analyser/tests/test_statistics.py
+++ b/analyser/tests/test_statistics.py
@@ -50,16 +50,12 @@ def test_create_statistics(
             }
         ]
     )
-    mock_generate_output_file.assert_called_once_with(
-        configuration, mock_data_frame.return_value
-    )
+    mock_generate_output_file.assert_called_once_with(configuration, mock_data_frame.return_value)
 
 
 @patch(f"{FILE_PATH}.get_commits")
 @patch(f"{FILE_PATH}.git.Repo")
-def test_create_repository_statistics(
-    _mock_repo: MagicMock, mock_get_commits: MagicMock
-) -> None:
+def test_create_repository_statistics(_mock_repo: MagicMock, mock_get_commits: MagicMock) -> None:
     # Arrange
     repository_name = "Test1"
     path_to_repo = "TestPath"

--- a/tests/schema_validation/repository_statistics_schema.json
+++ b/tests/schema_validation/repository_statistics_schema.json
@@ -1,34 +1,42 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
-  "type": "array",
-  "items": [
-    {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string"
-        },
-        "total_files": {
-          "type": "integer"
-        },
-        "total_commits": {
-          "type": "integer"
-        },
-        "commits": {
-          "type": "object"
-        },
-        "languages": {
-          "type": "object"
+  "type": "object",
+  "properties": {
+    "repository_owner": {
+      "type": "string"
+    },
+    "repositories": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "total_files": {
+              "type": "integer"
+            },
+            "total_commits": {
+              "type": "integer"
+            },
+            "commits": {
+              "type": "object"
+            },
+            "languages": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "repository",
+            "total_files",
+            "total_commits",
+            "commits",
+            "languages"
+          ]
         }
-      },
-      "required": [
-        "repository",
-        "total_files",
-        "total_commits",
-        "commits",
-        "languages"
       ]
     }
-  ]
+  }
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes significant changes to the `analyser/statistics.py` file, the corresponding tests, and the schema validation for repository statistics. The main changes involve the introduction of a new function for generating output files and updating the tests and schema to accommodate this new functionality.

### Key Changes:

#### New Functionality:
* Added a new function `generate_output_file` in `analyser/statistics.py` to handle the creation of output files. This function takes a configuration and a dataframe as arguments and writes the data to a JSON file.

#### Refactoring:
* Refactored the `create_statistics` function to use the new `generate_output_file` function instead of directly writing to a JSON file.

#### Testing:
* Updated the test file `analyser/tests/test_statistics.py` to include tests for the new `generate_output_file` function. This includes adding a patch for `generate_output_file` in existing tests and creating a new test specifically for this function. [[1]](diffhunk://#diff-96ff6623a4ce15f9e281c09ed90d0b0c46f7a01c7cff18ad2e0a821b22fb5e15L3-R12) [[2]](diffhunk://#diff-96ff6623a4ce15f9e281c09ed90d0b0c46f7a01c7cff18ad2e0a821b22fb5e15R24) [[3]](diffhunk://#diff-96ff6623a4ce15f9e281c09ed90d0b0c46f7a01c7cff18ad2e0a821b22fb5e15R53) [[4]](diffhunk://#diff-96ff6623a4ce15f9e281c09ed90d0b0c46f7a01c7cff18ad2e0a821b22fb5e15R69-R88)

#### Schema Validation:
* Modified the `repository_statistics_schema.json` file to include new properties for `repository_owner` and `repositories`, ensuring that the JSON output adheres to the updated schema. [[1]](diffhunk://#diff-f2ae76f93583821645527d189948b6dbb8e68c831573dd54d4b3483d172de4e8R4-R9) [[2]](diffhunk://#diff-f2ae76f93583821645527d189948b6dbb8e68c831573dd54d4b3483d172de4e8R41-R42)

These changes enhance the modularity and test coverage of the codebase, making it more maintainable and robust.

Fixes #264 
