### PR TITLE
ci: Add Actionlint Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -289,3 +289,18 @@ jobs:
           path: tests/github_summary
       - name: Test GitHub Summary
         run: just test-github-summary
+
+  run-actionlint:
+    name: Check GitHub Actions with actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an addition to the `.github/workflows/code-checks.yml` file to enhance the CI pipeline by adding a new job for linting GitHub Actions workflows.

Enhancements to CI pipeline:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R292-R306): Added a new job `run-actionlint` to check GitHub Actions workflows using `actionlint`. This job includes steps to checkout the repository, install `actionlint`, and run `actionlint` on the workflow files.

Fixes #269 
