### PR TITLE
ci: Add Zizmor Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize]
-  schedule:
-    - cron: 30 1 * * 0
 
 permissions:
   contents: read
@@ -23,6 +21,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.1.0
@@ -52,6 +51,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Check Python Code Quality (Ruff)
@@ -76,6 +76,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Check Python Code Quality (Ruff)
@@ -99,6 +100,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3.27.5
         with:
@@ -110,13 +114,12 @@ jobs:
   check-markdown-links:
     name: Check Markdown links
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check Markdown links
         uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
@@ -129,17 +132,14 @@ jobs:
   check-justfile-format:
     name: Check Justfile Format
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
+          persist-credentials: false
       - name: Set up Just
         uses: extractions/setup-just@v2
-
       - name: Check Justfile Format
         run: just format-check
 
@@ -153,6 +153,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Just
         uses: extractions/setup-just@v2
       - name: Set up Docker Buildx
@@ -171,6 +172,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Run Code Limit"
         uses: getcodelimit/codelimit-action@v1
 
@@ -182,6 +184,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Run Unit Tests
@@ -194,6 +197,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor
+
   run-local-action:
     name: Run Local Action
     runs-on: ubuntu-latest
@@ -202,6 +230,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Run GitHub Stats Analyser
@@ -232,6 +261,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Download Artifact
@@ -251,6 +281,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Download Artifact


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the GitHub Actions workflow configuration file `.github/workflows/code-checks.yml`. The most important changes include the removal of the scheduled cron job, the addition of the `persist-credentials` parameter to multiple `actions/checkout` steps, and the addition of a new job to check GitHub Actions with `zizmor`.

Key changes:

* Removal of the scheduled cron job:
  * Removed the `schedule` section that contained the cron job configuration.

* Addition of `persist-credentials` parameter:
  * Added `persist-credentials: false` to multiple `actions/checkout` steps to ensure credentials are not persisted across steps. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R24) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R54) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R79) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R103-R105) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L113-R122) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L132-L142) [[7]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R156) [[8]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R175) [[9]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R187) [[10]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R233) [[11]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R264) [[12]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R284)

* Addition of a new job to check GitHub Actions with `zizmor`:
  * Introduced a new job named `run-zizmor` to check GitHub Actions using `zizmor`, including steps to install `uv`, run `zizmor`, and upload the SARIF file.

Fixes #270 
