### PR TITLE
chore: Set markdown-link-checker job runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -211,7 +211,7 @@ jobs:
 
   run-local-action:
     name: Run Local Action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -102,7 +102,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /
 
 RUN mkdir -p /statistics && \
   mkdir -p /cloned_repositories && \
-  apk add --no-cache git=2.47.1-r0
+  apk add --no-cache git
 
 COPY --chmod=755 run.sh run.sh
 COPY analyser analyser

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /
 
 RUN mkdir -p /statistics && \
   mkdir -p /cloned_repositories && \
-  apk add --no-cache git
+  apk add --no-cache git=2.47.2-r0
 
 COPY --chmod=755 run.sh run.sh
 COPY analyser analyser


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow and the Dockerfile to ensure compatibility with newer versions of the operating system and software packages. The most important changes include updating the runner version for GitHub Actions and updating the Git version in the Dockerfile.

Updates to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L105-R105): Changed the runner version from `ubuntu-latest` to `ubuntu-22.04` for the `check-markdown-links` job.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L214-R214): Changed the runner version from `ubuntu-latest` to `ubuntu-22.04` for the `run-local-action` job.

Updates to Dockerfile:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L18-R18): Updated the Git version from `2.47.1-r0` to `2.47.2-r0` to ensure compatibility with the latest features and security updates.