### PR TITLE
ci: Update SuperLinter Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,11 +26,11 @@ jobs:
           persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.1
+        uses: super-linter/super-linter/slim@v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
           VALIDATE_PYTHON_BLACK: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.github/workflows/code-checks.yml` file. The change upgrades the version of the `super-linter` used for linting and corrects the GitHub token environment variable.

Changes to linting setup:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L29-R33): Updated `super-linter` version from `v7.2.1` to `v7.3.0` and corrected the GitHub token environment variable from `secrets.GH_TOKEN` to `secrets.GITHUB_TOKEN`.