### PR TITLE
chore: Add GitHub Action Step Name

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: micnncim/action-label-syncer@v1.3.0
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/workflows/sync-labels.yml` file. The change adds a descriptive `name` field to the label syncing step in the GitHub Actions workflow.

* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L25-R26): Added a `name` field ("Sync labels") to the label syncing step for better clarity in the workflow logs.