### PR TITLE
ci: Remove Pinact Verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -298,17 +298,3 @@ jobs:
           path: tests/github_summary
       - name: Test GitHub Summary
         run: just test-github-summary
-
-  pinact-verify:
-    name: Pinact Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `pinact-verify` job from the `.github/workflows/code-checks.yml` file. The job previously included steps for checking out the repository and installing the latest version of `uv`.

Key change:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L301-L314): Removed the `pinact-verify` job, including its associated steps for repository checkout and `uv` installation.