### PR TITLE
deps(github-actions): Bump astral-sh/setup-uv to 6.0.0

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -6,9 +6,6 @@ runs:
   steps:
     - name: Install Python and UV
       uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
-      with:
-        pyproject-file: "pyproject.toml"
-        enable-cache: true
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python Dependencies

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -5,12 +5,12 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
         pyproject-file: "pyproject.toml"
         enable-cache: true
     - name: Set up Just
-      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python Dependencies
       shell: bash
       run: just install

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -148,7 +148,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Build Docker Image

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -91,8 +91,6 @@ jobs:
           persist-credentials: false
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
-        with:
-          version: "latest"
       - name: Run Lefthook Validate
         run: uvx lefthook validate
 

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -40,7 +40,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: .
           push: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies in the GitHub Actions workflows to use newer versions, ensuring compatibility and taking advantage of the latest features and fixes. The changes primarily affect the `setup-uv`, `setup-just`, and `docker/build-push-action` actions.

### Dependency Updates:

* `.github/actions/setup-dependencies/action.yml`:
  - Updated `setup-uv` action from version `v5.4.2` to `v6.0.0`.
  - Updated `setup-just` action from version `v3` to `v3.0.0`.

* `.github/workflows/code-checks.yml`:
  - Updated `setup-uv` action from version `v5.4.2` to `v6.0.0` in the "Install the latest version of uv" step.
  - Updated `setup-just` action from version `v3` to `v3.0.0` in multiple steps. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L151-R149) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L167-R165)

* `.github/workflows/release-package.yml`:
  - Updated `docker/build-push-action` from version `v6.15.0` to `v6.16.0` in the "Build and push Docker image" step.