### PR TITLE
chore: Annotate Unit Test Failures

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -194,6 +194,8 @@ jobs:
           persist-credentials: false
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
+      - name: Install pytest-github-actions-annotate-failures
+        run: uv pip install pytest-github-actions-annotate-failures
       - name: Run Unit Tests
         run: just unit-test
       - name: Override Coverage Source Path for SonarCloud


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a small update to the `.github/workflows/code-checks.yml` file. It adds a step to install the `pytest-github-actions-annotate-failures` package, improving test failure annotations during CI runs.
