### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -26,7 +26,7 @@ updates:
       prefix: "deps(python)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       python:
@@ -42,7 +42,7 @@ updates:
       prefix: "deps(docker)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       docker:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -26,9 +25,8 @@ updates:
     commit-message:
       prefix: "deps(python)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       python:
@@ -43,10 +41,8 @@ updates:
     commit-message:
       prefix: "deps(docker)"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       docker:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the scheduling configuration for Dependabot in the `.github/dependabot.yml` file. The changes replace the previous interval-based schedules with a unified cron-based schedule for all dependency groups.

Scheduling updates:

* Changed the `github-actions` dependency group schedule from a daily interval at 01:00 (Europe/London timezone) to a cron-based schedule of `30 7 * * *`. (`.github/dependabot.yml`, [.github/dependabot.ymlL12-R13](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R13))
* Changed the `python` dependency group schedule from a daily interval at 01:00 (Europe/London timezone) to a cron-based schedule of `30 7 * * *`. (`.github/dependabot.yml`, [.github/dependabot.ymlL29-R29](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L29-R29))
* Changed the `docker` dependency group schedule from a weekly interval on Saturdays at 01:00 (Europe/London timezone) to a cron-based schedule of `30 7 * * *`. (`.github/dependabot.yml`, [.github/dependabot.ymlL46-R45](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L46-R45))