### PR TITLE
chore: Fix dependabot pull request titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       - "/"
       - ".github/actions/setup-dependencies"
       - ".github/actions/local"
+    commit-message:
+      prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to include a custom commit message prefix for GitHub Actions dependency updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R9-R10): Added a `commit-message` section with the prefix `"deps(github-actions)"` to standardize commit messages for GitHub Actions dependency updates.
