### PR TITLE
ci: Migrate Clear Caches to Common Clear Caches

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -5,20 +5,13 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   clean-caches:
-    name: Clean GitHub Action Caches
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Delete caches
-        run: gh cache delete --all --repo ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    name: Clean Caches
+    permissions:
+      contents: read
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
+    secrets:
+      workflow_github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the `clean-caches` workflow by replacing its inline implementation with a reusable workflow. Additionally, it updates permissions and secrets configuration for better clarity and security.

### Workflow simplification:
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL8-R17): Replaced the inline steps for cleaning GitHub Action caches with a reusable workflow from `JackPlowman/reusable-workflows`. This reduces redundancy and centralizes the logic.

### Configuration updates:
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL8-R17): Updated `permissions` to an empty object (`{}`) at the top level and added specific `contents: read` permissions within the job, ensuring a more precise and secure permissions setup.
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL8-R17): Introduced a `secrets` block to explicitly map `GH_TOKEN` to `workflow_github_token` for the reusable workflow, improving clarity in secret usage.