### PR TITLE
chore: Add ty Just Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -82,7 +82,6 @@ docker-run:
 
 # ------------------------------------------------------------------------------
 # Ruff - Python Linting and Formatting
-# Set up ruff red-knot when it's ready
 # ------------------------------------------------------------------------------
 
 # Fix all Ruff issues
@@ -110,6 +109,14 @@ ruff-format-check:
 # Fix Ruff format issues
 ruff-format-fix:
     uv run ruff format .
+
+# ------------------------------------------------------------------------------
+# Ty - Python Type Checking
+# ------------------------------------------------------------------------------
+
+# Check for type issues with Ty
+ty-check:
+    uv run ty check .
 
 # ------------------------------------------------------------------------------
 # Other Python Tools


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `Justfile` by removing outdated comments and adding a new command for Python type checking using `Ty`. 

Updates to `Justfile`:

* Removed the comment about setting up Ruff red-knot, as it is no longer relevant. (`docker-run:` in `Justfile`, [JustfileL85](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL85))
* Added a new section for Python type checking, including the `ty-check` command to run type checks with `Ty`. (`ruff-format-check:` in `Justfile`, [JustfileR113-R120](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR113-R120))