### PR TITLE
ci: Split Python Code Check Jobs

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -42,8 +42,8 @@ jobs:
           VALIDATE_NATURAL_LANGUAGE: false
           GITHUB_ACTIONS_COMMAND_ARGS: "-ignore '.branding.icon.'"
 
-  run-python-code-checks:
-    name: Run Python Code Checks
+  run-python-lint-checks:
+    name: Run Python Lint Checks
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -67,14 +67,41 @@ jobs:
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
-      - name: Check Python Code Format (Ruff)
-        run: just ruff-format-check
-        env:
-          RUFF_OUTPUT_FORMAT: "github"
       - name: Check Python Code Linting (Ruff)
         run: just ruff-lint-check
         env:
           RUFF_OUTPUT_FORMAT: "github"
+
+  run-python-format-checks:
+    name: Run Python Format Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up dependencies
+        uses: ./.github/actions/setup-dependencies
+      - name: Check Python Code Format (Ruff)
+        run: just ruff-format-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
+
+  run-python-code-checks:
+    name: Run Python Code Checks
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up dependencies
+        uses: ./.github/actions/setup-dependencies
       - name: Check Python Code for Dead Code (Vulture)
         run: just vulture
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/code-checks.yml` file to restructure and expand the Python code checks workflow. The changes include renaming existing jobs for clarity, splitting responsibilities into distinct jobs, and adding new jobs to improve modularity and coverage.

### Workflow restructuring and job updates:

* Renamed the `run-python-code-checks` job to `run-python-lint-checks` for better clarity and alignment with its purpose.
* Split the Python code format check into a new job called `run-python-format-checks`, separating it from lint checks for improved modularity and organization.
* Added a new `run-python-code-checks` job that consolidates setup steps and includes a code dead-check using Vulture. This enhances the workflow by introducing security-related permissions and improving code quality checks.
