### PR TITLE
chore: Fix Ty Warnings

### DIFF
--- a/analyser/utils/github_interactions.py
+++ b/analyser/utils/github_interactions.py
@@ -4,10 +4,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from git import Repo
-from github import Github, PaginatedList, Repository
+from github import Github, PaginatedList
 from structlog import get_logger, stdlib
 
 if TYPE_CHECKING:
+    from github.Repository import Repository
+
     from .configuration import Configuration
 
 logger: stdlib.BoundLogger = get_logger()

--- a/analyser/utils/tests/test_catalogued_repository.py
+++ b/analyser/utils/tests/test_catalogued_repository.py
@@ -10,7 +10,7 @@ def test_catalogued_repository() -> None:
     languages = RepositoryLanguages()
     languages.add_file(language_name="Python", file_path="file.py")
     languages.add_sloc(language_name="Python", sloc=100)
-    commits = []
+    commits = {}
     # Act
     catalogued_repository = CataloguedRepository(
         repository_name,


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes minor adjustments to improve type annotations and correct the data structure used in test cases. 

Type annotation improvements:
* [`analyser/utils/github_interactions.py`](diffhunk://#diff-9daf497280263c19671ee128b1a969169d4a14fc300a0b144de606a5a6c7318cL7-R12): Adjusted imports to ensure compatibility with `TYPE_CHECKING` by moving `Repository` import into the conditional block.

Test case corrections:
* [`analyser/utils/tests/test_catalogued_repository.py`](diffhunk://#diff-2d5d99851d3b7750ebee1e5c6e3ec31b7e186a8e6c2cefbd4f54861fe59fca8eL13-R13): Changed the `commits` variable from a list to a dictionary in the `test_catalogued_repository` function to align with expected data structure usage.
