### PR TITLE
ci: Set Ruff to use Colour

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   packages: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check-code-quality:
     name: Check Code Quality


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/code-checks.yml` file. The change adds an `env` variable `FORCE_COLOR` with a value of `1` to ensure colored output during code quality checks.
