### PR TITLE
ci: Remove CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -180,21 +180,6 @@ jobs:
       - name: Build Docker Image
         run: just docker-build
 
-  run-code-limit:
-    name: Run CodeLimit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1
-
   unit-test:
     name: Run Unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `run-code-limit` job from the `.github/workflows/code-checks.yml` file. The job previously ran CodeLimit checks as part of the CI pipeline.

Key change:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L183-L197): Removed the `run-code-limit` job, including its configuration and steps, which were responsible for running CodeLimit checks during the CI process.