### PR TITLE
ci: Remove SuperLinter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,6 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"

--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -12,11 +12,7 @@ dependencies:
 configurations:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [
-                ".github/other-configurations/*",
-                ".github/super-linter-configurations/*",
-              ]
+          - any-glob-to-any-file: [".github/other-configurations/*"]
 # Language
 markdown:
   - any:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,37 +16,6 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  check-code-quality:
-    name: Check Code Quality
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Lint Code Base
-        uses: super-linter/super-linter@5119dcd8011e92182ce8219d9e9efc82f16fddb6 # v8.0.0
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LINTER_RULES_PATH: .github/super-linter-configurations
-          YAML_ERROR_ON_WARNING: true
-          VALIDATE_EDITORCONFIG: false
-          VALIDATE_GIT_COMMITLINT: false
-          VALIDATE_NATURAL_LANGUAGE: false
-          VALIDATE_PYTHON_BLACK: false
-          VALIDATE_PYTHON_FLAKE8: false
-          VALIDATE_PYTHON_ISORT: false
-          VALIDATE_PYTHON_MYPY: false
-          VALIDATE_PYTHON_PYLINT: false
-          VALIDATE_PYTHON_RUFF: false
-          GITHUB_ACTIONS_COMMAND_ARGS: "-ignore '.branding.icon.'"
-          FILTER_REGEX_EXCLUDE: .vscode/launch.json
-
   run-python-lint-checks:
     name: Run Python Lint Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the use of the `super-linter` tool and its related configuration from the repository. The changes simplify the workflow and configuration files by eliminating references to `super-linter` and its associated paths.

**Removal of super-linter integration:**

* Deleted the entire `check-code-quality` job from the `.github/workflows/code-checks.yml` workflow, which previously ran `super-linter` on the codebase.
* Removed the `super-linter/super-linter` entry from the `exclude-patterns` list in `.github/dependabot.yml`, as it is no longer relevant.
* Updated `.github/other-configurations/labeller.yml` to remove references to `.github/super-linter-configurations/*` in the changed-files globs, reflecting the removal of super-linter configuration files.
