### PR TITLE
chore: Fix Markdown Links

### DIFF
--- a/.github/tool-configurations/labeller.yml
+++ b/.github/tool-configurations/labeller.yml
@@ -12,7 +12,7 @@ dependencies:
 configurations:
   - any:
       - changed-files:
-          - any-glob-to-any-file: [".github/other-configurations/*"]
+          - any-glob-to-any-file: [".github/tool-configurations/*"]
 # Language
 markdown:
   - any:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - .github/other-configurations/labels.yml
+      - .github/tool-configurations/labels.yml
   workflow_dispatch:
 
 permissions: {}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   - [Usage](#usage)
     - [GitHub Action Example](#github-action-example)
     - [GitHub Action Inputs](#github-action-inputs)
-  - [License](#license)
+  - [📄 License](#-license)
 
 ## Introduction
 
@@ -39,6 +39,6 @@ The GitHub Action is designed to be used in a workflow.
 | `GITHUB_TOKEN`     | no       | A GitHub token to authenticate API requests.        | string | `${{ github.token }}` |
 | `DEBUG`            | no       | Enable debug logging.                               | string | `false`               |
 
-## License
+## 📄 License
 
-[MIT](https://github.com/jackplowman/github-stats-analyser/blob/master/LICENSE)
+This project is licensed under the MIT Licence - see the [LICENCE](LICENCE) file for details.


### PR DESCRIPTION
# Pull Request

## Description

This pull request mainly updates configuration paths to improve consistency and clarity, and makes minor improvements to documentation. The most important changes include updating references to the correct configuration directory and enhancing the license section in the `README.md`.

Configuration updates:
* Changed the path for label configuration in `.github/workflows/sync-labels.yml` from `.github/other-configurations/labels.yml` to `.github/tool-configurations/labels.yml` to match the new directory structure.
* Updated the glob pattern in `.github/tool-configurations/labeller.yml` dependencies to use `.github/tool-configurations/*` instead of `.github/other-configurations/*`.

Documentation improvements:
* Updated the license section in `README.md` to use an emoji and clarified the license reference, linking to the local `LICENCE` file instead of a GitHub URL. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R44)
