### PR TITLE
chore: Update License to Licence

### DIFF
--- a/.github/tool-configurations/labeller.yml
+++ b/.github/tool-configurations/labeller.yml
@@ -21,7 +21,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor correction to the file pattern for labeling documentation-related files in `.github/tool-configurations/labeller.yml`. The change updates the pattern to match the correct spelling of the license file.

* Changed `"LICENSE"` to `"LICENCE"` in the `markdown:` file patterns to ensure proper labeling of documentation files.