### PR TITLE
ci: Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   check-pull-request-title:
     name: Check Pull Request Title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check Pull Request Title
         uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the permissions structure in the `.github/workflows/pull-request-tasks.yml` file. The main change is to move the `pull-requests: read` permission from the global workflow level to the specific job level for `check-pull-request-title`.

Workflow permissions update:

* The global `permissions` block is replaced with an empty object, and the `pull-requests: read` permission is now set only for the `check-pull-request-title` job. This scopes down the permission to just where it's needed, following GitHub Actions best practices.